### PR TITLE
fix: props can be undefined making stacks crash

### DIFF
--- a/src/components/stack/stack.component.tsx
+++ b/src/components/stack/stack.component.tsx
@@ -104,7 +104,7 @@ const Stack: React.FunctionComponent<StackProps> = (incomingProps) => {
             <React.Fragment key={`stack-${index}`}>
               {!!item && (
                 <React.Fragment>
-                  <RNView style={{ zIndex: item.props.zIndex }}>{item}</RNView>
+                  <RNView style={{ zIndex: item.props?.zIndex }}>{item}</RNView>
                   {index !== children.length - 1 ? (
                     <RNView style={computedStyle.stackSpacing} />
                   ) : null}


### PR DESCRIPTION
This pull request solves https://github.com/BearStudio/react-native-ficus-ui/issues/38