### PR TITLE
Fix switch colorscheme and circle size

### DIFF
--- a/docs/pages/docs/Components/Inputs/switch.en-US.mdx
+++ b/docs/pages/docs/Components/Inputs/switch.en-US.mdx
@@ -42,7 +42,7 @@ render(<SimpleSwitch />)`} noInline />
 
 ### `colorScheme`
 
-The background to-tint color of switch when is active.
+The colorScheme property, will define background color of switch when is active.
 
 | Type   | Required |
 | ------ | -------- |
@@ -50,7 +50,7 @@ The background to-tint color of switch when is active.
 
 ### `activeBg`
 
-The background tainted color of switch when is active.
+The background color of switch when is active.
 
 | Type   | Required | Default   |
 | ------ | -------- | --------- |

--- a/docs/pages/docs/Components/Inputs/switch.en-US.mdx
+++ b/docs/pages/docs/Components/Inputs/switch.en-US.mdx
@@ -42,11 +42,19 @@ render(<SimpleSwitch />)`} noInline />
 
 ### `colorScheme`
 
-The background color of switch when is active.
+The background to-tint color of switch when is active.
 
-| Type   | Required | Default |
-| ------ | -------- | ------- |
-| string | No       | green   |
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
+
+### `activeBg`
+
+The background tainted color of switch when is active.
+
+| Type   | Required | Default   |
+| ------ | -------- | --------- |
+| string | No       | green.300 |
 
 ### `bg`
 

--- a/docs/pages/docs/Components/Inputs/switch.en-US.mdx
+++ b/docs/pages/docs/Components/Inputs/switch.en-US.mdx
@@ -38,23 +38,34 @@ render(<SimpleSwitch />)`} noInline />
 }
 render(<SimpleSwitch />)`} noInline />
 
+### Change thumb size
+
+<CodeEditor code={`const SimpleSwitch = () => {
+  const [on, toggle] = React.useState(false);
+
+  return (
+    <Switch thumbSize={8} on={on} onPress={() => toggle(!on)} />
+  );
+}
+render(<SimpleSwitch />)`} noInline />
+
 ## Props
 
 ### `colorScheme`
 
 The colorScheme property, will define background color of switch when is active.
 
-| Type   | Required |
-| ------ | -------- |
-| string | No       |
+| Type   | Required | Default |
+| ------ | -------- | ------- |
+| string | No       | green   |
 
 ### `activeBg`
 
 The background color of switch when is active.
 
-| Type   | Required | Default   |
-| ------ | -------- | --------- |
-| string | No       | green.300 |
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 ### `bg`
 
@@ -79,6 +90,14 @@ The background color of thumb when toggle is on.
 | Type   | Required | Default |
 | ------ | -------- | ------- |
 | string | No       | white   |
+
+### `thumbSize`
+
+The size of thumb component.
+
+| Type   | Required | Default |
+| ------ | -------- | ------- |
+| number | No       | 24      |
 
 ### `isDisabled`
 

--- a/example/app/components/Switch.tsx
+++ b/example/app/components/Switch.tsx
@@ -6,6 +6,7 @@ import ExampleSection from '@/src/ExampleSection';
 const SwitchComponent = () => {
   const [on, toggle] = useState(false);
   const [on2, toggle2] = useState(false);
+  const [on3, toggle3] = useState(false);
   return (
     <SafeAreaView>
       <Text mx="xl" fontSize="4xl">
@@ -17,6 +18,9 @@ const SwitchComponent = () => {
         </ExampleSection>
         <ExampleSection name="change color">
           <Switch colorScheme="red" on={on2} onPress={() => toggle2(!on2)} />
+        </ExampleSection>
+        <ExampleSection name="change thumb size">
+          <Switch thumbSize={8} on={on3} onPress={() => toggle3(!on3)} />
         </ExampleSection>
       </ScrollBox>
     </SafeAreaView>

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -18,11 +18,10 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
       w: 55,
       h: 30,
       onPress: (): void => {},
-      colorScheme: '',
-      activeBg: 'green.300',
+      colorScheme: 'green',
       bg: 'gray.400',
       on: false,
-      thumbSize: 12,
+      thumbSize: 24,
       thumbBg: 'white',
       activeThumbBg: 'white',
       duration: 300,
@@ -79,7 +78,6 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
   } = props;
   const [animXValue] = useState(new Animated.Value(on ? 1 : 0));
   const computedStyle = getStyle(theme, props);
-
   const endPos = (w as number) - thumbSize - 3;
   const circlePosXEnd = endPos;
   const [circlePosXStart] = useState(3);
@@ -123,7 +121,7 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
                 getThemeColor(theme.colors, bg),
                 getThemeColor(
                   theme.colors,
-                  props.colorScheme ? `${props.colorScheme}.500` : activeBg
+                  props.activeBg ? props.activeBg : `${colorScheme}.500`
                 ),
               ],
             }),
@@ -133,11 +131,7 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
         <Animated.View
           style={[
             computedStyle.circle,
-
             {
-              width: thumbSize,
-              height: thumbSize,
-              borderRadius: Math.max(thumbSize / 2, 2),
               backgroundColor: animXValue.interpolate({
                 inputRange: [0, 1],
                 outputRange: [

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -19,7 +19,7 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
       h: 30,
       onPress: (): void => {},
       colorScheme: '',
-      activeBg: 'green',
+      activeBg: 'green.300',
       bg: 'gray.400',
       on: false,
       thumbSize: 12,

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -21,6 +21,7 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
       colorScheme: 'green',
       bg: 'gray.400',
       on: false,
+      thumbSize: 12,
       thumbBg: 'white',
       activeThumbBg: 'white',
       duration: 300,
@@ -67,6 +68,7 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
     borderEndWidth,
     onPress,
     colorScheme,
+    thumbSize,
     thumbBg,
     activeThumbBg,
     duration,
@@ -76,7 +78,7 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
   const [animXValue] = useState(new Animated.Value(on ? 1 : 0));
   const computedStyle = getStyle(theme, props);
 
-  const endPos = (w as number) - (h as number) + 3;
+  const endPos = (w as number) - (thumbSize as number) - 3;
   const circlePosXEnd = endPos;
   const [circlePosXStart] = useState(3);
 
@@ -117,7 +119,7 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
               inputRange: [0, 1],
               outputRange: [
                 getThemeColor(theme.colors, bg),
-                getThemeColor(theme.colors, `${props.colorScheme}.500`),
+                getThemeColor(theme.colors, props.colorScheme),
               ],
             }),
           },
@@ -126,7 +128,11 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
         <Animated.View
           style={[
             computedStyle.circle,
+
             {
+              width: thumbSize,
+              height: thumbSize,
+              borderRadius: Math.max(thumbSize / 2, 2),
               backgroundColor: animXValue.interpolate({
                 inputRange: [0, 1],
                 outputRange: [

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -18,7 +18,8 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
       w: 55,
       h: 30,
       onPress: (): void => {},
-      colorScheme: 'green',
+      colorScheme: '',
+      activeBg: 'green',
       bg: 'gray.400',
       on: false,
       thumbSize: 12,
@@ -68,6 +69,7 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
     borderEndWidth,
     onPress,
     colorScheme,
+    activeBg,
     thumbSize,
     thumbBg,
     activeThumbBg,
@@ -78,7 +80,7 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
   const [animXValue] = useState(new Animated.Value(on ? 1 : 0));
   const computedStyle = getStyle(theme, props);
 
-  const endPos = (w as number) - (thumbSize as number) - 3;
+  const endPos = (w as number) - thumbSize - 3;
   const circlePosXEnd = endPos;
   const [circlePosXStart] = useState(3);
 
@@ -119,7 +121,10 @@ const Switch: React.FC<SwitchProps> = (incomingProps) => {
               inputRange: [0, 1],
               outputRange: [
                 getThemeColor(theme.colors, bg),
-                getThemeColor(theme.colors, props.colorScheme),
+                getThemeColor(
+                  theme.colors,
+                  props.colorScheme ? `${props.colorScheme}.500` : activeBg
+                ),
               ],
             }),
           },

--- a/src/components/switch/switch.style.tsx
+++ b/src/components/switch/switch.style.tsx
@@ -27,11 +27,11 @@ export const getStyle = (theme: ThemeType, props: SwitchProps) => {
 
   computedStyle.circle = {
     // @ts-ignore
-    height: props.h - 6,
+    height: props.thumbSize,
     // @ts-ignore
-    width: props.h - 6,
+    width: props.thumbSize,
     // @ts-ignore
-    borderRadius: props.h - 6,
+    borderRadius: Math.max(props.thumbSize / 2, 2),
   };
 
   // merging style props to computed style

--- a/src/components/switch/switch.type.tsx
+++ b/src/components/switch/switch.type.tsx
@@ -24,6 +24,7 @@ export interface SwitchProps
   on?: boolean;
   onPress: () => void;
   colorScheme?: string;
+  activeBg?: string;
   thumbSize?: number;
   thumbBg?: string;
   activeThumbBg?: string;

--- a/src/components/switch/switch.type.tsx
+++ b/src/components/switch/switch.type.tsx
@@ -24,6 +24,7 @@ export interface SwitchProps
   on?: boolean;
   onPress: () => void;
   colorScheme?: string;
+  thumbSize?: number;
   thumbBg?: string;
   activeThumbBg?: string;
   duration?: number;


### PR DESCRIPTION
Closes Issue#43

### ThumbSize

With thumbSize = 4
![image](https://github.com/user-attachments/assets/b12b20df-27aa-4c26-a0cb-cefe154ce1c9)

With thumbSize = 14
![image](https://github.com/user-attachments/assets/ad52cb9d-b660-444e-be81-1619840d1b91)

Default thumbSize = 12 
![image](https://github.com/user-attachments/assets/dffb6d44-44f6-448d-85b9-44a85d6db6ec)


---

### ActiveBg

activeBg is a color.tint and allows the use of personalized tint.

With a custom color activeBg={colors.brand[950]}
![image](https://github.com/user-attachments/assets/e3d803a0-ca2f-47f0-9e95-9bc5135099f5)

With a nuanced color activeBg="green.200"
![image](https://github.com/user-attachments/assets/8a936665-7203-4e61-b6d7-efb7833e2113)

With a color colorScheme="blue"
![image](https://github.com/user-attachments/assets/6e6e23e8-d109-4e04-a81c-d9f6ce330d79)

With a color that is not found colorScheme="fushia"
![image](https://github.com/user-attachments/assets/70cf9740-c46c-4ea5-924f-cac3be402f61)

**ColorScheme takes priority over activeBg that is set to 'green.300' by default.**

