### PR TITLE
fix(tabs):  linkedTo props added and Tabs type updated

### DIFF
--- a/src/components/tabs/tabs.component.tsx
+++ b/src/components/tabs/tabs.component.tsx
@@ -13,7 +13,7 @@ import {
 import { Text } from '../text/text.component';
 import { getThemeColor } from '../../theme/theme.service';
 
-const Tab: FC<TabProps> = ({ name, children, ...rest }) => {
+const Tab: FC<TabProps> = ({ children, ...rest }) => {
   const { theme } = useTheme();
   const styles = getStyle(theme, rest);
   return <View style={styles.box}>{children as ReactNode}</View>;

--- a/src/components/tabs/tabs.type.ts
+++ b/src/components/tabs/tabs.type.ts
@@ -1,10 +1,6 @@
 import { ReactNode } from 'react';
 import { ViewStyle, TextStyle } from 'react-native';
-import type {
-  TabViewProps as RNTabViewProps,
-  Route,
-  SceneRendererProps,
-} from 'react-native-tab-view';
+import type { Route, SceneRendererProps } from 'react-native-tab-view';
 import type {
   BorderPropsType,
   SpacingPropsType,
@@ -35,9 +31,7 @@ type CommonStyleProps = BorderPropsType &
   VariantPropsType;
 
 // Extend CommonStyleProps with specific props for each component
-export interface TabsProps<T extends Route = Route>
-  extends CommonStyleProps,
-    RNTabViewProps<T> {
+export interface TabsProps extends CommonStyleProps {
   colorScheme?: string;
   children: ReactNode;
   initialPage?: number;
@@ -51,6 +45,7 @@ export interface TabListProps extends CommonStyleProps {
 }
 
 export interface TabPanelProps extends CommonStyleProps {
+  linkedTo: string;
   children: ReactNode;
   // Additional props can be added if needed
 }


### PR DESCRIPTION
1. unused name props in tabs.component.tsx deleted

2. unused type deleted as the RNTabViewProps are used within the View that is returned in the tabs component. : 
```
export interface TabsProps<T extends Route = Route>
  extends CommonStyleProps,
    RNTabViewProps<T> {
  colorScheme?: string;
  children: ReactNode;
  initialPage?: number;
  selectedTab?: number;
  onChangeTab: (index: number) => void;
}
 ```
 
 3. linkedTo props added to TabPanel
 

 
 
 